### PR TITLE
【スタンダード第30回課題（続）】異常系テスト追加

### DIFF
--- a/src/test/java/raisetech/StudentManagement/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/StudentRepositoryTest.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,6 +36,18 @@ class StudentRepositoryTest {
   }
 
   @Test
+  void 存在しないIDでは受講生が取得できないこと() {
+    Student student = sut.searchStudent("999");
+    assertThat(student).isNull();
+  }
+
+  @Test
+  void nullのIDで検索した場合はnullが返ること() {
+    Student student = sut.searchStudent(null);
+    assertThat(student).isNull();
+  }
+
+  @Test
   void 全ての受講生コース情報が取得できること() {
     List<StudentCourse> courses = sut.searchStudentCourseList();
     assertThat(courses.size()).isEqualTo(10);
@@ -65,6 +78,16 @@ class StudentRepositoryTest {
 
     assertThat(actual.size()).isEqualTo(6);
   }
+
+  @Test
+  void 必須項目が抜けている受講生は登録できないこと() {
+    Student student = new Student();
+    student.setEmail("invalid@example.com"); // 名前など未設定
+
+    assertThatThrownBy(() -> sut.registerStudent(student))
+        .isInstanceOf(Exception.class); // 実装に合わせて調整
+  }
+
 
   @Test
   void コース登録が行えること() {


### PR DESCRIPTION
異常系テスト（null・存在しないID・不正な登録）３つのメソッドを追加

・ullのIDで検索した場合はnullが返ること
例外が返るようにしようかとも思いましたが、例外クラスの役割も取り込んでしまいそうなので、やめました。

ご確認お願い致します。