### PR TITLE
Standard第31回課題〈1〉コース申込状況

### DIFF
--- a/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/StudentManagement/data/StudentCourse.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement.data;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -29,9 +30,15 @@ public class StudentCourse {
 
   @Schema(description = "コース開始日", example = "2024-04-01T00:00:00")
   @NotNull(message = "コース開始日は必須です。")
+  @JsonProperty("courseStartAt")
   private LocalDateTime courseStartAt;
 
   @Schema(description = "コース終了日", example = "2025-04-01T00:00:00")
   @NotNull(message = "コース終了日は必須です。")
+  @JsonProperty("courseEndAt")
   private LocalDateTime courseEndAt;
+
+  @Schema(description = "コースステータス（仮申込・本申込・受講中・受講終了）", example = "仮申込")
+  @JsonProperty("status")
+  private String status = "仮申込";
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -81,6 +81,11 @@ public class StudentService {
     studentCourse.setStudentId(id);
     studentCourse.setCourseStartAt(now);
     studentCourse.setCourseEndAt(now.plusYears(1));
+
+    // status が null または空文字だったら、自動で仮申込に！
+    if (studentCourse.getStatus() == null || studentCourse.getStatus().isBlank()) {
+      studentCourse.setStatus("仮申込");
+    }
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # MyBatis???
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:/mapper/*.xml
+# Spring?????????DEBUG???
+logging.level.root=DEBUG
+logging.level.org.springframework.web=DEBUG

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -16,12 +16,15 @@
 
   <!-- 受講生コース情報の全件検索 -->
   <select id="searchStudentCourseList" resultType="raisetech.StudentManagement.data.StudentCourse">
-    SELECT * FROM students_courses
+    SELECT id, student_id, course_name, course_start_at, course_end_at, status
+    FROM students_courses
   </select>
 
   <!-- 受講生IDに紐づくコース情報検索 -->
   <select id="searchStudentCourse" resultType="raisetech.StudentManagement.data.StudentCourse">
-    SELECT * FROM students_courses WHERE student_id = #{studentId}
+    SELECT id, student_id, course_name, course_start_at, course_end_at, status
+    FROM students_courses
+    WHERE student_id = #{studentId}
   </select>
 
   <!-- 受講生の新規登録（IDは自動採番） -->
@@ -31,11 +34,11 @@
     VALUES(#{name}, #{kanaName}, #{nickname}, #{email}, #{area}, #{age}, #{sex}, #{remark}, false)
   </insert>
 
-  <!-- 受講生コース情報の新規登録（IDは自動採番） -->
+  <!-- 受講生コース情報の新規登録（IDは自動採番・statusは自動的に「仮申込」として登録） -->
   <insert id="registerStudentCourse" useGeneratedKeys="true" keyProperty="id"
     parameterType="raisetech.StudentManagement.data.StudentCourse">
-    INSERT INTO students_courses(student_id, course_name, course_start_at, course_end_at)
-    VALUES(#{studentId}, #{courseName}, #{courseStartAt}, #{courseEndAt})
+    INSERT INTO students_courses(student_id, course_name, course_start_at, course_end_at, status)
+    VALUES(#{studentId}, #{courseName}, #{courseStartAt}, #{courseEndAt}, #{status})
   </insert>
 
   <!-- 受講生の更新 -->
@@ -56,8 +59,14 @@
   <!-- 受講生コース情報のコース名更新（IDで指定） -->
   <update id="updateStudentCourse" parameterType="raisetech.StudentManagement.data.StudentCourse">
     UPDATE students_courses
-    SET course_name = #{courseName}
+    <set>
+      <if test="courseName != null">course_name = #{courseName},</if>
+      <if test="courseStartAt != null">course_start_at = #{courseStartAt},</if>
+      <if test="courseEndAt != null">course_end_at = #{courseEndAt},</if>
+      <if test="status != null">status = #{status},</if>
+    </set>
     WHERE id = #{id}
   </update>
+
 
 </mapper>

--- a/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/StudentManagement/controller/StudentControllerTest.java
@@ -126,6 +126,37 @@ class StudentControllerTest {
   }
 
   @Test
+  void 受講生の更新でステータスが含まれていてもエラーが出ないこと() throws Exception {
+    mockMvc.perform(put("/updateStudent").contentType(MediaType.APPLICATION_JSON).content(
+        """
+            {
+              "student": {
+                "id": "1",
+                "name": "江並公史",
+                "kanaName": "エナミコウジ",
+                "nickname": "エナミ",
+                "email": "test@example.com",
+                "area": "奈良県",
+                "age": "36",
+                "sex": "男性",
+                "remark": ""
+              },
+              "studentCourseList":[
+                {
+                  "id": "1",
+                  "studentId": "1",
+                  "courseName": "Javaコース",
+                  "courseStartAt": "2024-04-01T10:00:00",
+                  "courseEndAt": "2025-04-01T10:00:00",
+                  "status": "本申込"
+                }
+              ]
+            }
+            """
+    )).andExpect(status().isOk());
+  }
+
+  @Test
   void 受講生詳細の例外APIが実行できてステータスが400で返ってくること() throws Exception {
     mockMvc.perform(get("/exception"))
         .andDo(print()) // ← 追加！

--- a/src/test/java/raisetech/StudentManagement/converter/StudentConverterTest.java
+++ b/src/test/java/raisetech/StudentManagement/converter/StudentConverterTest.java
@@ -38,8 +38,8 @@ public class StudentConverterTest {
 
     assertThat(actual.get(0).getStudent()).isEqualTo(student);
     assertThat(actual.get(0).getStudentCourseList()).isEqualTo(studentCourseList);
+    assertThat(actual.get(0).getStudentCourseList().get(0).getStatus()).isEqualTo("仮申込");
   }
-
 
   @Test
   void 受講生のリストと受講生コース情報のリストを渡したときに紐づかない受講生情報は除外されること() {

--- a/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/StudentManagement/repository/StudentRepositoryTest.java
@@ -130,5 +130,15 @@ class StudentRepositoryTest {
         .isEqualTo("変更されたコース");
   }
 
+  @Test
+  void コースのステータスが更新できること() {
+    List<StudentCourse> courses = sut.searchStudentCourse("1");
+    StudentCourse course = courses.get(0);
+    course.setStatus("受講終了");
 
+    sut.updateStudentCourse(course);
+
+    List<StudentCourse> updated = sut.searchStudentCourse("1");
+    assertThat(updated.get(0).getStatus()).isEqualTo("受講終了");
+  }
 }

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -155,5 +155,25 @@ class StudentServiceTest {
     verify(repository, times(1)).updateStudent(student);
     verify(repository, times(1)).updateStudentCourse(studentCourse);
   }
+
+  @Test
+  void 受講生コース情報の更新でステータスが正しく反映されること() {
+    Student student = new Student();
+    StudentCourse course = new StudentCourse();
+    course.setId("1");
+    course.setStudentId("1");
+    course.setCourseName("Javaコース");
+    course.setCourseStartAt(LocalDateTime.now());
+    course.setCourseEndAt(LocalDateTime.now().plusMonths(6));
+    course.setStatus("受講中");
+
+    List<StudentCourse> courseList = List.of(course);
+    StudentDetail detail = new StudentDetail(student, courseList);
+
+    sut.updateStudent(detail);
+
+    verify(repository, times(1)).updateStudentCourse(course);
+    assertEquals("受講中", course.getStatus());
+  }
 }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=StudentManagement2
 spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
 spring.datasource.url=jdbc:h2:~/test;MODE=MySQL
 spring.datasource.username=sa
 spring.datasource.password=sa
 spring.datasource.driver-class-name=org.h2.Driver
 spring.h2.console.enabled=true
-# MyBatis???
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:/mapper/*.xml

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -18,5 +18,6 @@ CREATE TABLE IF NOT EXISTS students_courses
     student_id INT NOT NULL,
     course_name VARCHAR(50) NOT NULL,
     course_start_at TIMESTAMP,
-    course_end_at TIMESTAMP
+    course_end_at TIMESTAMP,
+    status VARCHAR(20)
 );


### PR DESCRIPTION
<img width="652" alt="Standard31-1" src="https://github.com/user-attachments/assets/0b7f8a53-9ee3-4933-ba65-c9c466f27ea6" />



Standard第31回課題の、まずコース申し込み状況の導入部分をPRいたします。
・コース申込状況（ステータス）機能の追加とテスト完了

他の機能部分は、また作成後にPRさせていただきます。
ご確認お願い致します

１．Mysql の受講生コース情報に、status項目追加済み。
・登録時、自動的に「仮申込」となるよう設定

<img width="785" alt="Standard31-2" src="https://github.com/user-attachments/assets/ad08627a-4c3d-4e4d-a29e-a265acb3830f" />



２．status項目追加について、Intellijの各クラスにも追加。
・登録時、空欄であれば、自動的に「仮申込」になるよう設定など。Mysqlの漏れ対策。
・Postmanにてコース名だけでなく、statusも更新できるよう、再設定。
・Postmanで、status含めた全件/個別検索・更新・登録できることを確認済み。
→Intellijでは実行成功でも、Postmanにて500エラー発生時のエラー原因見れるよう、
application.propertiesで、ログ確認できるよう、フレームワーク追加。

<img width="960" alt="Standard31-3" src="https://github.com/user-attachments/assets/23eb1458-e38b-445e-b0c8-8d369708c23e" />
<img width="960" alt="Standard31-4" src="https://github.com/user-attachments/assets/3e55250b-1aba-45f4-be7b-015ba44c004b" />
<img width="960" alt="Standard31-5" src="https://github.com/user-attachments/assets/3cbd765a-e415-44d8-9ade-a067b3a4e526" />



３．追加できたstatusについて、Testクラス４つにメソッド追加。
・すべてテスト完了100％になったことも、確認済み。

<img width="960" alt="Standard31-6" src="https://github.com/user-attachments/assets/d486f200-8473-4d6f-a10e-860d332e40a2" />
