### PR TITLE
条件付き検索機能の追加（名前・性別・地域・削除済み）

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.StudentSearchCondition;
 import raisetech.StudentManagement.exceptionHandler.TestException;
 import raisetech.StudentManagement.service.StudentService;
 
@@ -46,6 +47,16 @@ public class StudentController {
   @GetMapping("/studentList")
   public List<StudentDetail> getStudentList() {
     return service.searchStudentList();
+  }
+
+  /**
+   * 条件指定による受講生検索です。
+   */
+  @Operation(summary = "条件付き検索", description = "名前・性別・地域・削除フラグで受講生を検索します。")
+  @GetMapping("/searchStudent")
+  public List<StudentDetail> searchStudentsByCondition(
+      @Validated StudentSearchCondition condition) {
+    return service.searchStudentsByConditions(condition);
   }
 
   // 新しく追加
@@ -81,6 +92,18 @@ public class StudentController {
   public StudentDetail getStudent(
       @PathVariable @NotBlank @Pattern(regexp = "^\\d+$") String id) {
     return service.searchStudent(id);
+  }
+
+  /**
+   * 条件指定による受講生検索です。
+   *
+   * @param condition 検索条件（名前・性別など）
+   * @return 該当する受講生詳細のリスト
+   */
+  @Operation(summary = "条件検索", description = "条件を指定して受講生を検索します。")
+  @PostMapping("/students/search")
+  public List<StudentDetail> searchByConditions(@RequestBody StudentSearchCondition condition) {
+    return service.searchStudentsByConditions(condition);
   }
 
   /**

--- a/src/main/java/raisetech/StudentManagement/domain/StudentSearchCondition.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentSearchCondition.java
@@ -1,0 +1,19 @@
+package raisetech.StudentManagement.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 検索条件をまとめたDTOクラス（受講生検索用）
+ */
+@Getter
+@Setter
+public class StudentSearchCondition {
+
+  private String name;   // 名前（部分一致）
+  private String sex;    // 性別（完全一致）
+  private String area;   // 地域（部分一致）
+  private Boolean deleted; // 論理削除フラグ（true: 削除済、false: 有効）
+
+  // 必要なら age なども追加できる！
+}

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
+import raisetech.StudentManagement.domain.StudentSearchCondition;
 
 /**
  * 受講生テーブルと受講生コース情報テーブルと紐づくRepositoryです。
@@ -13,7 +14,7 @@ public interface StudentRepository {
 
   // 全受講生の取得
   List<Student> search();
-  
+
   // IDで受講生を検索
   Student searchStudent(String id);
 
@@ -34,4 +35,8 @@ public interface StudentRepository {
 
   // コース名の更新（1件）
   void updateStudentCourse(StudentCourse studentCourse);
+
+  //条件付き一覧検索
+  List<Student> searchByConditions(
+      StudentSearchCondition condition);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -10,6 +10,7 @@ import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.StudentSearchCondition;
 import raisetech.StudentManagement.repository.StudentRepository;
 
 /**
@@ -48,6 +49,18 @@ public class StudentService {
     Student student = repository.searchStudent(id);
     List<StudentCourse> studentCourse = repository.searchStudentCourse(student.getId());
     return new StudentDetail(student, studentCourse);
+  }
+
+  /**
+   * 条件付きの受講生検索です。
+   *
+   * @param condition 検索条件（名前・性別など）
+   * @return 条件に一致する受講生詳細のリスト
+   */
+  public List<StudentDetail> searchStudentsByConditions(StudentSearchCondition condition) {
+    List<Student> studentList = repository.searchByConditions(condition);
+    List<StudentCourse> courseList = repository.searchStudentCourseList();
+    return converter.convertStudentDetails(studentList, courseList);
   }
 
   /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # MyBatis???
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:/mapper/*.xml
+mybatis.type-aliases-package=raisetech.StudentManagement.data,raisetech.StudentManagement.domain
 # Spring?????????DEBUG???
 logging.level.root=DEBUG
 logging.level.org.springframework.web=DEBUG

--- a/src/main/resources/mapper/StudentRepository.xml
+++ b/src/main/resources/mapper/StudentRepository.xml
@@ -92,5 +92,25 @@
     WHERE id = #{id}
   </update>
 
-
+  <!-- 条件検索：動的SQL -->
+  <select id="searchByConditions"
+    parameterType="raisetech.StudentManagement.domain.StudentSearchCondition"
+    resultType="raisetech.StudentManagement.data.Student">
+    SELECT * FROM students
+    <where>
+      <if test="name != null and name != ''">
+        AND name LIKE CONCAT('%', #{name}, '%')
+      </if>
+      <if test="area != null and area != ''">
+        AND area = #{area}
+      </if>
+      <if test="sex != null and sex != ''">
+        AND sex = #{sex}
+      </if>
+      <if test="deleted != null">
+        AND is_deleted = #{deleted}
+      </if>
+    </where>
+  </select>
+  
 </mapper>

--- a/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/StudentManagement/service/StudentServiceTest.java
@@ -17,6 +17,7 @@ import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 import raisetech.StudentManagement.domain.StudentDetail;
+import raisetech.StudentManagement.domain.StudentSearchCondition;
 import raisetech.StudentManagement.repository.StudentRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -176,6 +177,33 @@ class StudentServiceTest {
     verify(repository, times(1)).updateStudentCourse(course);
     assertEquals(2, course.getStatusId());
     assertEquals("受講中", course.getStatusName());
+  }
+
+  @Test
+  void 条件指定検索_リポジトリとコンバーターが正しく呼び出されること() {
+    // --- 準備 ---
+    var condition = new StudentSearchCondition();
+    condition.setName("スネ夫");
+    condition.setSex("男性");
+    condition.setArea("東京都");
+
+    List<Student> mockStudentList = new ArrayList<>();
+    List<StudentCourse> mockCourseList = new ArrayList<>();
+    List<StudentDetail> expectedDetails = new ArrayList<>();
+
+    when(repository.searchByConditions(condition)).thenReturn(mockStudentList);
+    when(repository.searchStudentCourseList()).thenReturn(mockCourseList);
+    when(converter.convertStudentDetails(mockStudentList, mockCourseList)).thenReturn(
+        expectedDetails);
+
+    // --- 実行 ---
+    List<StudentDetail> actual = sut.searchStudentsByConditions(condition);
+
+    // --- 検証 ---
+    verify(repository).searchByConditions(condition);
+    verify(repository).searchStudentCourseList();
+    verify(converter).convertStudentDetails(mockStudentList, mockCourseList);
+    assertEquals(expectedDetails, actual);
   }
 }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,4 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.h2.console.enabled=true
 mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.mapper-locations=classpath:/mapper/*.xml
+mybatis.type-aliases-package=raisetech.StudentManagement.data,raisetech.StudentManagement.domain


### PR DESCRIPTION
スタンダード第31回課題〈続き〉提出　
・・・　条件付き検索機能の追加（名前・性別・地域・削除済み）

<img width="551" alt="Standard31-10" src="https://github.com/user-attachments/assets/c6f6eed4-4437-4d56-b6aa-ee0852110098" />

・domainパッケージにStudentSearchConditionを追加し、条件付き検索機能を追加。
他関連クラスも変更追加し、Postmanで動作確認済。
１．名前検索
<img width="960" alt="Standard31-15" src="https://github.com/user-attachments/assets/aa4135be-1240-4bb8-9d96-3b55dc156a98" />
２．性別検索
<img width="960" alt="Standard31-11" src="https://github.com/user-attachments/assets/e45d8093-8a1a-4e86-bfed-ef7946677403" />
３．地域検索
<img width="960" alt="Standard31-12" src="https://github.com/user-attachments/assets/66f8a89e-fc70-446e-ac3b-31a6f0ff0afb" />
４．未削除〈false〉／　削除済〈true〉検索
<img width="960" alt="Standard31-14" src="https://github.com/user-attachments/assets/92b5cc3f-1add-4c12-be17-58d2566e7f2f" />
<img width="960" alt="Standard31-13" src="https://github.com/user-attachments/assets/0762cc3d-c2a3-42b2-a913-2f2d2058497f" />

・テストも実行画面成功。ブラウザでも100％確認済。
<img width="960" alt="Standard31-17" src="https://github.com/user-attachments/assets/6db77e8d-2e80-4233-9e44-0db3106a87e2" />


補足；　Postmanでの削除を動作確認していなかったため、作成しました。
ただ、is_deleted欄をfalseかtrueに更新する画面を作る方法なのですが、これで動作確認は合ってますでしょうか？
　MysqlのTableからも完全削除をするとなると、ServiceやRepositoryクラス、Repository.xmlにdeleteメソッドを追加することになるので、今回の課題外の追加になってしまうと考え、追加していません。
　
<img width="960" alt="Standard31-16" src="https://github.com/user-attachments/assets/209b23a7-da93-466d-926e-0ba7783ef24c" />